### PR TITLE
fix: navbar and page content will never overlap now

### DIFF
--- a/app/(pages)/profile/page.module.css
+++ b/app/(pages)/profile/page.module.css
@@ -2,13 +2,13 @@
   display: flex;
   padding-left: 2rem;
   padding-right: 2rem;
-  padding-top: 2.5rem;
-  padding-bottom: 2.5rem;
+  padding-top: 0rem;
+  padding-bottom: 1rem;
   flex-direction: column;
   gap: 1rem;
   justify-content: space-evenly;
   align-items: center;
-  min-height: 100vh;
+  min-height: 100%;
   background-color: whitesmoke;
 
   @media (min-width: 576px) {
@@ -31,7 +31,7 @@
 .left_section {
   display: flex;
   flex-direction: column;
-  margin-top: 8rem;
+  margin-top: 2rem;
   margin-left: 4rem;
   margin-right: 4rem;
   width: 100%;

--- a/app/components/header.tsx
+++ b/app/components/header.tsx
@@ -4,7 +4,7 @@ import styles from './header.module.css';
 
 const Header: React.FC = () => {
     return (
-        <header className={styles.topnav}>
+        <header className="root-header">
             <div className="grid grid-cols-10 gap-2">
                 <div className="col-span-6 col-start-3">
                     <div className="coulmns-4 gap-2">
@@ -19,7 +19,6 @@ const Header: React.FC = () => {
                     <Link href="/signup">sign up</Link>
                 </div>
             </div>
-
         </header>
     );
 };

--- a/app/globals.css
+++ b/app/globals.css
@@ -60,3 +60,44 @@ hr {
   border-color: #d0abdfaf;
   width: 100%;
 }
+
+
+/*Layout.tsx styles to handle Navbar + Page content interaction*/
+:root {
+  /* --primary-color: #3498db;
+  --secondary-color: #ecf0f1; */
+  /* --padding: 20px; Example padding */
+}
+
+html, body {
+  height: 100%; /* Ensure html and body take full height */
+  margin: 0;
+  padding: 0;
+}
+
+.layout {
+  display: flex;
+  flex-direction: column;
+  height: 100vh; /* Make sure the layout takes the full viewport height */
+}
+
+.root-header {
+  /* This effectively sets a fixed height for the navbar */
+  /* If Header has an intrinsic height, flex: 0 0 auto will respect it */
+  flex: 0 0 auto; 
+  /* background-color: var(--primary-color); */
+  padding: 10px 20px; /* Example padding for header */
+  color: white; /* Example text color */
+}
+
+.root-page-content {
+  flex: 1; /* This makes the content area grow and take all available space */
+  overflow-y: auto; /* Adds scroll if content overflows vertically */
+  padding: var(--padding);
+  background-color: var(--secondary-color);
+}
+
+/* font variables */
+.nunito-sans-variable { font-family: var(--font-nunito-sans); }
+.inter-variable { font-family: var(--font-inter); }
+.zilla-slab-variable { font-family: var(--font-zilla-slab); }

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -31,8 +31,12 @@ export default function RootLayout({
   return (
     <html lang="en">
       <body className={`${nunitoSans.variable} ${inter.variable} ${zillaSlab.variable}`}>
-        <Header />
-        {children}
+        <div className="layout">
+          <Header />
+          <main className="root-page-content">
+            {children}
+          </main>
+        </div>
       </body>
     </html>
   );

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -3,7 +3,7 @@ import styles from "./page.module.css";
 
 export default function Home() {
   return (
-       <main>
+    <div>
         <div className={styles.content}>
             <h1>Responsible Computing Club</h1>
             <p>
@@ -26,6 +26,6 @@ export default function Home() {
                 <Image src="/icons/smiley-icon.svg" alt="Smiley" className={styles.smiley}  width="100" height="100"/>
             </div>
         </div>
-    </main>
+    </div>
   );
 }


### PR DESCRIPTION
Changes:
- globals.css has some basic root, body, and html styling
- add flex-grow styling for navbar and page content (will not overlap anymore)
- fixed profile page which was lightly affected by navbar + page content changes
- minor fixes to prevent hydration errors and clean up tags