### PR TITLE
refactor: common styling in globals.css

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -1,62 +1,109 @@
 @import "tailwindcss";
 
-h1 {
-  font-family: var(--font-zilla-slab);
-  font-size: 55.2px;
-  line-height: 115.2px;
-  text-align: left;
-  text-underline-position: from-font;
-  text-decoration-skip-ink: none;
-  color: #5C1C75;
+@theme inline {
+  /* some colors from Figma prototypes */
+  --color-brand-dark-grey: #383838;
+  --color-brand-dark-purple: #411A63;
+  --color-brand-indigo: #470085;
+  --color-brand-pale-purple: #DEB8FE;
+  --color-brand-cobalt-blue: #2F419B;
+  --color-brand-pale-blue: #E2E8FD;
+  --color-brand-dark-pastel-purple: #9580D7;
+  --color-brand-light-steel-blue: #7289DA;
+  --color-brand-lilac: #CDA8F9;
+
+  /* some Mozilla colors */
+  --color-brand-ironside-grey: #666666;
+  --color-brand-dark-dune-grey: #333333;
+
+  /* primary RCC brand colors */
+  --color-brand-dark-lavender: #7972a8;
+  --color-brand-lavender: #c4baea;
+  --color-brand-dull-periwinkle: #93a2e2;
+  --color-brand-baby-pink: #f6badf;
+  --color-brand-baby-blue: #9bd6f5;
+
+  /* supporting RCC brand colors */
+  --color-brand-dark-violet: #280b63;
+  --color-brand-pale-violet: #caaaf3;
+  --color-brand-dark-periwinkle: #576dd2;
 }
 
-h2 {
-  font-family: var(--font-inter);
-  font-size: 26px;
-  line-height: 58.09px;
-  text-underline-position: from-font;
-  text-decoration-skip-ink: none;
-  color: #5C1C75;
-  margin: 0;
+:root {
+  /* some colors from Figma prototypes */
+  --color-brand-dark-grey: #383838;
+  --color-brand-dark-purple: #411A63;
+  --color-brand-indigo: #470085;
+  --color-brand-pale-purple: #DEB8FE;
+  --color-brand-cobalt-blue: #2F419B;
+  --color-brand-pale-blue: #E2E8FD;
+  --color-brand-dark-pastel-purple: #9580D7;
+  --color-brand-light-steel-blue: #7289DA;
+  --color-brand-lilac: #CDA8F9;
+
+  /* some Mozilla colors */
+  --color-brand-ironside-grey: #666666;
+  --color-brand-dark-dune-grey: #333333;
+
+  /* primary RCC brand colors */
+  --color-brand-dark-lavender: #7972a8;
+  --color-brand-lavender: #c4baea;
+  --color-brand-dull-periwinkle: #93a2e2;
+  --color-brand-baby-pink: #f6badf;
+  --color-brand-baby-blue: #9bd6f5;
+
+  /* supporting RCC brand colors */
+  --color-brand-dark-violet: #280b63;
+  --color-brand-pale-violet: #caaaf3;
+  --color-brand-dark-periwinkle: #576dd2;
 }
 
-p {
-  font-family: var(--font-nunito-sans);
-  font-size: 19px;
-  width: 80%;
-  line-height: 49.1px;
-  text-underline-position: from-font;
-  text-decoration-skip-ink: none;
-  color: #000000C7;
-  margin: 0;
+@layer base {
+  body {
+    color: var(--color-brand-dark-grey);
+    font-family: var(--font-inter);
+  }
+
+  h1, h2, h3, h4, h5, h6 {
+    font-family: var(--font-zilla-slab);
+  }
+
+  h1 {
+    color: var(--color-brand-indigo);
+    font-size: 50pt;
+  }
+
+  p {
+    max-width: 70ch;
+    line-height: 1.5;
+    font-size: 19;
+    margin-bottom: 2.25em;
+  }
+
+  a {
+    color: var(--color-brand-indigo);
+  }
+
+  hr {
+    outline: black;
+    width: 100%;
+  }
 }
 
-li {
-  font-family: var(--font-nunito-sans);
-  font-size: 18px;
-  width: 80%;
-  font-weight: 500;
-  line-height: 49.1px;
-  text-underline-position: from-font;
-  text-decoration-skip-ink: none;
-  color: #000000C7;
-  margin: 0;
-
+.skip-to-content-link {
+  @apply bg-[var(--color-brand-dark-violet)] p-2 lg:p-3 top-2 left-2 absolute;
+  /* background: var(--color-brand-blue-peacock);
+  padding: 10px;
+  top: 1%;
+  left: 1%;
+  position: absolute;
+  transform: translateY(-100%); */
+  transition: transform 0.3s;
+  color: white;
+  outline-color: var(--color-brand-dark-periwinkle);
+  outline-offset: 3px;
 }
 
-a {
-  font-size: 19px;
-  width: 80%;
-  font-weight: 500;
-  line-height: 49.1px;
-  text-underline-position: from-font;
-  text-decoration-skip-ink: none;
-  color: #000000C7;
-  margin: 0;
-  text-decoration: none;
-}
-
-hr {
-  border-color: #d0abdfaf;
-  width: 100%;
+.skip-to-content-link:focus {
+  transform: translateY(0%);
 }


### PR DESCRIPTION
- added some common colors from the Figma prototypes, as well as some RCC brand colors
- basic styling of common elements, like body, p, and hr tags
- added a class for styling a skip to content link (an accessibility feature)